### PR TITLE
Skip full validation when using email as username

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -22,7 +22,7 @@ import {
 import { query } from '@restorecommerce/chassis-srv/lib/database/provider/arango/common';
 import {
   validateFirstChar, validateSymbolRepeat, validateAllChar,
-  validateStrLen, validateAtSymbol, validateEmail
+  validateStrLen, validateEmail
 } from './validation';
 import { TokenService } from './token_service';
 import { Arango } from '@restorecommerce/chassis-srv/lib/database/provider/arango/base';
@@ -974,9 +974,9 @@ export class UserService extends ServiceBase {
 
   // validUsername validates user names using regular expressions
   private validUsername(username: string, minLength: number, maxLength: number, logger: Logger) {
-    if (validateAtSymbol(username) == false) {
-      // false means that the username contains "@"
+    if (username.includes('@')) {
       validateEmail(username, logger);
+      return;
     }
     validateStrLen(username, minLength, maxLength, logger);
     validateFirstChar(username, logger);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -54,13 +54,6 @@ export const validateStrLen = (string: string, minLength: number,
   }
 };
 
-// validateAtSymbol checks if the string contains the "@" symbol
-// returns false if a symbol is present
-export const validateAtSymbol = (string: string): boolean => {
-  const regexp = new RegExp('^(?!.*@).+');
-  return !!string.match(regexp);
-};
-
 // validateEmail checks if the string input is a valid email
 export const validateEmail = (string: string, logger: Logger): boolean => {
   const regexp = new RegExp(/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);


### PR DESCRIPTION
Change fixes validation error when using specific email addresses as username. It was allowed to use an email address, but with some limitations. Validation rules related to classic username approach limit the registration using emails like `1test@example.com`.

I addition to that, the function `validateAtSymbol` has been replaced with a simpler condition check. The only thing the function does is checking by regex if a string given as input contains an `@` sign, which seems to be overengineered.